### PR TITLE
Bitfield refactor

### DIFF
--- a/byte_len.cr
+++ b/byte_len.cr
@@ -1,0 +1,32 @@
+require "spec"
+
+def byte_len(sbit, bit_length)
+  ((bit_length + sbit%8) / 8.0).ceil.to_i
+end
+
+describe "byte_length" do
+  it "should return 1" do
+    byte_len(32, 8).should eq 1
+  end
+  it "should return 2" do
+    byte_len(32, 16).should eq 2
+  end
+  it "should return 2" do
+    byte_len(32, 12).should eq 2
+  end
+  it "should return 2" do
+    byte_len(36, 8).should eq 2
+  end
+  it "should return 2" do
+    byte_len(36, 12).should eq 2
+  end
+  it "should return 3" do
+    byte_len(36, 16).should eq 3
+  end
+  it "should return 3" do
+    byte_len(36, 15).should eq 3
+  end
+  it "should return 3" do
+    byte_len(36, 17).should eq 3
+  end
+end

--- a/mapping.cr
+++ b/mapping.cr
@@ -1,0 +1,35 @@
+# module BitFields
+#   macro mapping(properties, strict = false)
+#     # {% for key, value in properties %}
+#     #   def {{key.var}}
+#     #     puts {{value}}
+#     #     puts "{{key.type}}"
+#     #   end
+#     # {% end %}
+#   end
+# end
+
+class BFTest
+  @@hello = Array(Int32).new
+  # @@hello = ""
+  @@hello << 12 
+  puts @@hello
+  @@hello << 4
+  puts @@hello
+  @@hello << 8 
+  puts @@hello
+  @@hello << 4
+  puts @@hello
+  @@hello << 4
+  puts @@hello
+
+  # BitFields.mapping(
+  #   name : UInt8 => 5,
+  #   house : UInt8 => 3,
+  # )
+  def self.hello
+    @@hello
+  end
+end
+
+puts BFTest.hello

--- a/refactor.cr
+++ b/refactor.cr
@@ -23,6 +23,10 @@ class BitFields
     end
   end
 
+  # starting_bit
+  # bit_length
+  # byte_length = (bit_length/8.0).ceil.to_i
+
   def fields
     fields = Hash(String, Int32).new
     {% for ivar in @type.methods %}
@@ -48,23 +52,23 @@ end
 
 class CrossBit < BitFields
   bf rpms : UInt32, 32
-  bf temp : UInt8, 4 
-  bf psi : UInt16, 9 
-  bf power : UInt8, 1 
-  bf lights : UInt8, 2 
-  bf v1 : UInt16, 16 
+  bf temp : UInt8, 4
+  bf psi : UInt16, 9
+  bf power : UInt8, 1
+  bf lights : UInt8, 2
+  bf v1 : UInt16, 16
   bf v2 : UInt8, 4
-  bf v3 : UInt8, 4 
-  bf v4 : UInt8, 8 
+  bf v3 : UInt8, 4
+  bf v4 : UInt8, 8
   bf v5 : UInt8, 8
 end
 
 crossbit = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
 puts crossbit.rpms
-puts crossbit.temp          #=> 13_u8
-puts crossbit.psi           #=> 342_u16
-puts crossbit.power         #=> 1_u8
-puts crossbit.lights        #=> 3_u8
+puts crossbit.temp   # => 13_u8
+puts crossbit.psi    # => 342_u16
+puts crossbit.power  # => 1_u8
+puts crossbit.lights # => 3_u8
 puts crossbit.v1
 puts crossbit.v2
 puts crossbit.v3

--- a/refactor.cr
+++ b/refactor.cr
@@ -52,14 +52,25 @@ class CrossBit < BitFields
   bf psi : UInt16, 9 
   bf power : UInt8, 1 
   bf lights : UInt8, 2 
+  bf v1 : UInt16, 16 
+  bf v2 : UInt8, 4
+  bf v3 : UInt8, 4 
+  bf v4 : UInt8, 8 
+  bf v5 : UInt8, 8
 end
 
-crossbit = CrossBit.new(Bytes[109, 121, 110, 97, 109, 245])
+crossbit = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
+puts crossbit.rpms
 puts crossbit.temp          #=> 13_u8
 puts crossbit.psi           #=> 342_u16
 puts crossbit.power         #=> 1_u8
 puts crossbit.lights        #=> 3_u8
-puts crossbit.rpms
+puts crossbit.v1
+puts crossbit.v2
+puts crossbit.v3
+puts crossbit.v4
+puts crossbit.v5
+
 # crossbit.to_slice      #=> Bytes[109, 121, 110, 97, 109, 245]
 
 # class TestB < BitFields

--- a/refactor.cr
+++ b/refactor.cr
@@ -52,18 +52,21 @@ end
 
 class CrossBit < BitFields
   bf rpms : UInt32, 32
-  bf temp : UInt8, 4
-  bf psi : UInt16, 9
-  bf power : UInt8, 1
-  bf lights : UInt8, 2
-  bf v1 : UInt16, 16
+  bf temp : UInt8, 4 
+  bf psi : UInt16, 9 
+  bf power : UInt8, 1 
+  bf lights : UInt8, 2 
+  bf v1 : UInt16, 16 
   bf v2 : UInt8, 4
-  bf v3 : UInt8, 4
-  bf v4 : UInt8, 8
+  bf v3 : UInt8, 8 
+  bf v4 : UInt8, 4 
   bf v5 : UInt8, 8
 end
 
-crossbit = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
+bytes = Bytes[109, 121, 110, 97, 221, 181, 220, 0, 28, 156, 9]
+crossbit = CrossBit.new(bytes)
+
+# crossbit = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
 puts crossbit.rpms
 puts crossbit.temp   # => 13_u8
 puts crossbit.psi    # => 342_u16

--- a/spec/bitfields_spec.cr
+++ b/spec/bitfields_spec.cr
@@ -117,7 +117,8 @@ describe BitFields do
     end
 
     it "should return string printout" do
-      crossbit.to_s.should eq "ajsdjfa"
+      str = "rpms -- Binary:01100001011011100111100101101101 Hex:616E796D Decimal:1634629997\ntemp -- Binary:1101 Hex:D Decimal:13\npsi -- Binary:100111111 Hex:13F Decimal:319\npower -- Binary:1 Hex:1 Decimal:1\nlights -- Binary:01 Hex:1 Decimal:1\nv1 -- Binary:0000000011100001 Hex:E1 Decimal:225\nv2 -- Binary:1101 Hex:D Decimal:13\nv3 -- Binary:10101101 Hex:AD Decimal:173\nv4 -- Binary:1110 Hex:E Decimal:14\nv5 -- Binary:01110011 Hex:73 Decimal:115"
+      crossbit.to_s.should eq str 
     end
   end
 end

--- a/spec/bitfields_spec.cr
+++ b/spec/bitfields_spec.cr
@@ -120,5 +120,11 @@ describe BitFields do
       str = "rpms -- Binary:01100001011011100111100101101101 Hex:616E796D Decimal:1634629997\ntemp -- Binary:1101 Hex:D Decimal:13\npsi -- Binary:100111111 Hex:13F Decimal:319\npower -- Binary:1 Hex:1 Decimal:1\nlights -- Binary:01 Hex:1 Decimal:1\nv1 -- Binary:0000000011100001 Hex:E1 Decimal:225\nv2 -- Binary:1101 Hex:D Decimal:13\nv3 -- Binary:10101101 Hex:AD Decimal:173\nv4 -- Binary:1110 Hex:E Decimal:14\nv5 -- Binary:01110011 Hex:73 Decimal:115"
       crossbit.to_s.should eq str 
     end
+
+    it "should return tuple" do
+      t =  {rpms: {value: 1634629997_u32, length: 32}, temp: {value: 13_u8, length: 4}, psi: {value: 319_u16, length: 9}, power: {value: 1_u8, length: 1}, lights: {value: 1_u8, length: 2}, v1: {value: 225_u16, length: 16}, v2: {value: 13_u8, length: 4}, v3: {value: 173_u8, length: 8}, v4: {value: 14_u8, length: 4}, v5: {value: 115_u8, length: 8}}
+      crossbit.to_t.should eq t 
+      #{name: {value: "isaac", length: 5}}
+    end
   end
 end

--- a/spec/bitfields_spec.cr
+++ b/spec/bitfields_spec.cr
@@ -6,10 +6,15 @@ class CrossBit < BitFields
   bf psi : UInt16, 9 
   bf power : UInt8, 1 
   bf lights : UInt8, 2 
+  bf v1 : UInt16, 16 
+  bf v2 : UInt8, 4
+  bf v3 : UInt8, 4 
+  bf v4 : UInt8, 8 
+  bf v5 : UInt8, 8
 end
 
 describe Bitfields do
-  bytes = Bytes[109, 121, 110, 97, 109, 245]
+  bytes = Bytes[109, 121, 110, 97, 109, 245, 57, 50, 56, 51, 52, 55, 56, 57, 50, 51, 56, 52, 55, 50, 57, 51, 56, 55, 50, 57, 51, 56, 52, 55]
   crossbit = CrossBit.new(bytes)
 
   it "should read 32 bits into a UInt32" do
@@ -44,7 +49,16 @@ describe Bitfields do
   it "should output modified bytes if values are modified" do
     crossbit.lights = 2
     crossbit.psi = 349
+    crossbit.v1 = 220 
+    crossbit.v2 = 97 
+    crossbit.v3 = 193 
+    crossbit.v5 = 38
+    crossbit.v4 = 105 
+    crossbit.to_s
+    puts crossbit.to_slice
     new_bytes = Bytes[109, 121, 110, 97, 221, 181] 
+    c2 = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
+    puts c2.to_s 
     crossbit.to_slice.should eq new_bytes
   end
 end

--- a/spec/bitfields_spec.cr
+++ b/spec/bitfields_spec.cr
@@ -8,57 +8,116 @@ class CrossBit < BitFields
   bf lights : UInt8, 2 
   bf v1 : UInt16, 16 
   bf v2 : UInt8, 4
-  bf v3 : UInt8, 4 
-  bf v4 : UInt8, 8 
+  bf v3 : UInt8, 8 
+  bf v4 : UInt8, 4 
   bf v5 : UInt8, 8
 end
 
-describe Bitfields do
-  bytes = Bytes[109, 121, 110, 97, 109, 245, 57, 50, 56, 51, 52, 55, 56, 57, 50, 51, 56, 52, 55, 50, 57, 51, 56, 55, 50, 57, 51, 56, 52, 55]
-  crossbit = CrossBit.new(bytes)
-
-  it "should read 32 bits into a UInt32" do
-    crossbit.rpms.should eq 1634629997
-    crossbit.rpms.class.should eq UInt32
+describe BitFields do
+  describe "Class" do
+    describe "byte_length" do
+      it "should return 1" do
+        BitFields.byte_len(32, 8).should eq 1
+      end
+      it "should return 2" do
+        BitFields.byte_len(32, 16).should eq 2
+      end
+      it "should return 2" do
+        BitFields.byte_len(32, 12).should eq 2
+      end
+      it "should return 2" do
+        BitFields.byte_len(36, 8).should eq 2
+      end
+      it "should return 2" do
+        BitFields.byte_len(36, 12).should eq 2
+      end
+      it "should return 3" do
+        BitFields.byte_len(36, 16).should eq 3
+      end
+      it "should return 3" do
+        BitFields.byte_len(36, 15).should eq 3
+      end
+      it "should return 3" do
+        BitFields.byte_len(36, 17).should eq 3
+      end
+    end
   end
 
-  it "should read first 4 bits into a UInt8" do
-    crossbit.temp.should eq 13 
-    crossbit.temp.class.should eq UInt8
-  end
+  describe "Instance" do
+    bytes = Bytes[109, 121, 110, 97, 221, 181, 220, 0, 28, 252, 105]
+    crossbit = CrossBit.new(bytes)
 
-  it "should read the next 9 bits from across bytes into a UInt16" do
-    crossbit.psi.should eq 342 
-    crossbit.psi.class.should eq UInt16
-  end
+    it "should read 32 bits into a UInt32" do
+      crossbit.rpms.should eq 1634629997
+      crossbit.rpms.class.should eq UInt32
+    end
 
-  it "should read the next bit into UInt8" do
-    crossbit.power.should eq 1 
-    crossbit.power.class.should eq UInt8
-  end
+    it "should read first 4 bits into a UInt8" do
+      crossbit.temp.should eq 13 
+      crossbit.temp.class.should eq UInt8
+    end
 
-  it "should read the next 2 bits to end of byte into UInt8" do
-    crossbit.lights.should eq 3
-    crossbit.lights.class.should eq UInt8
-  end
+    it "should read the next 9 bits from across bytes into a UInt16" do
+      crossbit.psi.should eq 349 
+      crossbit.psi.class.should eq UInt16
+    end
 
-  it "should output the same Bytes which were read in" do
-    crossbit.to_slice.should eq bytes 
-  end
+    it "should read the next bit into UInt8" do
+      crossbit.power.should eq 1 
+      crossbit.power.class.should eq UInt8
+    end
 
-  it "should output modified bytes if values are modified" do
-    crossbit.lights = 2
-    crossbit.psi = 349
-    crossbit.v1 = 220 
-    crossbit.v2 = 97 
-    crossbit.v3 = 193 
-    crossbit.v5 = 38
-    crossbit.v4 = 105 
-    crossbit.to_s
-    puts crossbit.to_slice
-    new_bytes = Bytes[109, 121, 110, 97, 221, 181] 
-    c2 = CrossBit.new(Bytes[109, 121, 110, 97, 221, 181, 220, 0, 113, 101, 38])
-    puts c2.to_s 
-    crossbit.to_slice.should eq new_bytes
+    it "should read the next 2 bits to end of byte into UInt8" do
+      crossbit.lights.should eq 2
+      crossbit.lights.class.should eq UInt8
+    end
+
+    it "should read v1 correctly" do
+      crossbit.v1.should eq 220 
+    end
+
+    it "should read v2 correctly" do
+      crossbit.v2.should eq 12 
+    end
+
+    it "should read v3 correctly" do
+      crossbit.v3.should eq 193 
+    end
+
+    it "should read v4 correctly" do
+      crossbit.v4.should eq 15 
+    end
+
+    it "should read v5 correctly" do
+      crossbit.v5.should eq 105 
+    end
+
+    it "should output modified bytes if values are modified" do
+      crossbit.lights = 1
+      crossbit.psi = 319
+      crossbit.v1 = 225 
+      crossbit.v2 = 13 
+      crossbit.v3 = 173 
+      crossbit.v4 = 14 
+      crossbit.v5 = 115 
+      new_bytes = Bytes[109, 121, 110, 97, 253, 115, 225, 0, 221, 234, 115]
+      crossbit.to_slice.should eq new_bytes
+    end
+
+    it "should read in new bytes and print out correct values" do
+      c2 = CrossBit.new(crossbit.to_slice)
+
+      crossbit.lights.should eq 1
+      crossbit.psi.should eq 319
+      crossbit.v1.should eq 225 
+      crossbit.v2.should eq 13 
+      crossbit.v3.should eq 173 
+      crossbit.v4.should eq 14 
+      crossbit.v5.should eq 115 
+    end
+
+    it "should return string printout" do
+      crossbit.to_s.should eq "ajsdjfa"
+    end
   end
 end

--- a/src/bitfields.cr
+++ b/src/bitfields.cr
@@ -66,9 +66,7 @@ class BitFields
     def to_s
       %titles = %bits = "|"
       {% for name, type, index in FIELDS %}
-        %color = Colorize::ColorRGB.new(*COLORS[{{index}} % COLORS.size].map(&.to_u8))
-        %titles = %(|#{"{{name.id}}".colorize(%color)}#{%titles})
-        %bits = %(|#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}}).colorize(%color)}#{%bits})
+        puts "{{name.id}}: #{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} -- #{ {{name.id}} }"
       {% end %}       
       [%titles, %bits].join("\n")
     end

--- a/src/bitfields.cr
+++ b/src/bitfields.cr
@@ -72,7 +72,8 @@ class BitFields
     def to_s
       %str_arr = Array(String).new
       {% for name, type, index in FIELDS %}
-        %str_arr << "{{name.id}} -- Binary:#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} Hex:#{sprintf("%0{#{({{LENGTHS[index]}}/8.0).ceil.to_i}x", {{name.id}})} Decimal:#{ {{name.id}} }"
+        # %str_arr << "{{name.id}} -- Binary:#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} Hex:#{sprintf("%0{#{({{LENGTHS[index]}}/8.0).ceil.to_i}x", {{name.id}})} Decimal:#{ {{name.id}} }"
+        %str_arr << "{{name.id}} -- Binary:#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} Hex:#{sprintf("%X", {{name.id}})} Decimal:#{ {{name.id}} }"
       {% end %}
       %str_arr.join("\n")
     end

--- a/src/bitfields.cr
+++ b/src/bitfields.cr
@@ -38,12 +38,10 @@ class BitFields
         %byte_len = self.class.byte_len(%sbit, %bit_len)
         %buffer = 0_u64
         %bytes[%sbit/8, %byte_len].each.with_index do |b, i|
-          # puts "in byte loop {{name.id}}, #{i}"
           %buffer ^= (b.to_u64 << i*8)
         end
         %buffer >>= (%sbit % 8)
         %buffer &= (2**%bit_len-1)
-        puts %buffer.to_s(2), %buffer if "{{name.id}}" == "v3"
         %sbit += %bit_len
         @{{name.id}} = {{type.id}}.new(%buffer)
       {% end %}
@@ -54,7 +52,6 @@ class BitFields
       %byte_index = 0
       %buffer : UInt64 = 0
       %head = 0
-
       {% for name, type, index in FIELDS %}
         %buffer ^= ({{name.id}}.to_u64 << %head)
         %head += {{LENGTHS[index]}}
@@ -69,10 +66,17 @@ class BitFields
       %bytes
     end
 
+    def to_t
+      {
+      {% for name, type, index in FIELDS %}
+        {{name.id}}: {value: @{{name.id}}, length: {{LENGTHS[index]}} },
+      {% end %}
+      }
+    end
+
     def to_s
       %str_arr = Array(String).new
       {% for name, type, index in FIELDS %}
-        # %str_arr << "{{name.id}} -- Binary:#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} Hex:#{sprintf("%0{#{({{LENGTHS[index]}}/8.0).ceil.to_i}x", {{name.id}})} Decimal:#{ {{name.id}} }"
         %str_arr << "{{name.id}} -- Binary:#{sprintf("%0{{LENGTHS[index]}}b", {{name.id}})} Hex:#{sprintf("%X", {{name.id}})} Decimal:#{ {{name.id}} }"
       {% end %}
       %str_arr.join("\n")


### PR DESCRIPTION
* Refactored to be more readable.
* Fixed edge case where bit lengths divisible by 8 that started in the middle of the starting byte would be calculated wrong.
* Added to_tuple method
* Refactored to_s to work for longer fields.